### PR TITLE
[ADD] base_json_request: Module to allow standard JSON requests

### DIFF
--- a/base_json_request/README.rst
+++ b/base_json_request/README.rst
@@ -1,0 +1,50 @@
+.. image:: https://img.shields.io/badge/licence-LGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+   :alt: License: LGPL-3
+
+=================
+Base JSON Request
+=================
+
+This module allows you to receive JSON requests in Odoo that are not
+RPC.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/210/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/server-tools/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Dave Lasley <dave@laslabs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/base_json_request/__init__.py
+++ b/base_json_request/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from .hooks import post_load

--- a/base_json_request/__manifest__.py
+++ b/base_json_request/__manifest__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+{
+    'name': 'Base JSON Request',
+    'summary': 'Allows you to receive JSON requests that are not RPC.',
+    'version': '10.0.1.0.0',
+    'category': 'Authentication',
+    'website': 'https://laslabs.com/',
+    'author': 'LasLabs, Odoo Community Association (OCA)',
+    'license': 'LGPL-3',
+    'installable': True,
+    'depends': [
+        'web',
+    ],
+    'post_load': 'post_load',
+}

--- a/base_json_request/hooks.py
+++ b/base_json_request/hooks.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import http
+
+from .http import _handle_exception, __init__
+
+
+def post_load():
+    """Monkey patch HTTP methods."""
+    http.JsonRequest._handle_exception = _handle_exception
+    http.JsonRequest.__init__ = __init__

--- a/base_json_request/http.py
+++ b/base_json_request/http.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 LasLabs Inc.
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+import json
+
+from werkzeug.exceptions import BadRequest
+
+from odoo import http
+
+
+old_handle_exception = http.JsonRequest._handle_exception
+old_init = http.JsonRequest.__init__
+
+
+def __init__(self, *args):
+    try:
+        old_init(self, *args)
+    except BadRequest as e:
+        try:
+            args = self.httprequest.args
+            self.jsonrequest = args
+            self.params = json.loads(self.jsonrequest.get('params', "{}"))
+            self.context = self.params.pop('context',
+                                           dict(self.session.context))
+        except ValueError:
+            raise e
+
+
+def _handle_exception(self, exception):
+    """ Override the original method to handle Werkzeug exceptions.
+
+    Args:
+        exception (Exception): Exception object that is being thrown.
+
+    Returns:
+        BaseResponse: JSON Response.
+    """
+
+    # For some reason a try/except here still raised...
+    code = getattr(exception, 'code', None)
+    if code is None:
+        return old_handle_exception(
+            self, exception,
+        )
+
+    error = {
+        'data': http.serialize_exception(exception),
+        'code': code,
+    }
+
+    try:
+        error['message'] = exception.description
+    except AttributeError:
+        try:
+            error['message'] = exception.message
+        except AttributeError:
+            error['message'] = 'Internal Server Error'
+
+    return self._json_response(error=error)


### PR DESCRIPTION
* Create a module that circumvents the JSON-RPC requirement for all requests with application/json

This logic is taken from my REST API work in  OCA/server-tools#889. It has been working well on multiple productions for a few months now. Note that none of these productions have multiple databases, which is an important detail in this instance (because this is a monkey patch).

That said, I do not intend to provide compatibility for multi-tenant here. I assert that the concept of a webhook and the concept of a multi-tenant Odoo instance are at odds with each other in most cases. 

While multi-tenant is still a possibility while just using this module, the next PR I submit (`base_web_hook` - #4) will have an explicit note that this is not possible. IMO it is worth having the ability for a web hook, as long as the possible sacrifice is known. This may be possible to circumvent with database filters, but I haven't tested.

cc @moylop260 (I think you guys were looking for something like this for Gitlab webhooks) 

Note: I still need to add tests, but the functionality is here to review.